### PR TITLE
feat: Add Product API endpoint with schema and router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,11 @@
 from fastapi import FastAPI
 from routes.health import router as health_router
 from routes.ping import router as ping_router
+from routes.products import router as product_router
 app = FastAPI()
 app.include_router(health_router)
 app.include_router(ping_router)
+app.include_router(product_router)
 @app.get("/")
 def read_root():
     return {"msg": "Welcome to the Backend Developer Hub FastAPI!"}

--- a/app/routes/products.py
+++ b/app/routes/products.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+from schemas.products import ProductResponse, ProductCreate
+
+router = APIRouter()
+
+@router.post('/products', response_model=ProductResponse)
+async def product_create(product: ProductCreate):
+    return {'id': 1, 'name': product.name, 'price': product.price}

--- a/app/schemas/products.py
+++ b/app/schemas/products.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+class ProductCreate(BaseModel):
+    name: str 
+    price: float
+    
+class ProductResponse(BaseModel):
+    id: int
+    name: str
+    price: float
+    
+    class Config:
+        from_attributes=True


### PR DESCRIPTION
## Description

I've implemented the Product API endpoint as requested in issue #19.

### Changes Made
- Created `ProductCreate` and `ProductResponse` Pydantic schemas
- Created `product.py` router with POST `/products` endpoint
- Integrated the product router into `main.py`
- Tested the endpoint in Swagger UI

### Notes
This is my first contribution to this project. 
If anything needs adjustment or improvement, I'm happy to make changes!